### PR TITLE
Defer I/O until the data is needed

### DIFF
--- a/search.py
+++ b/search.py
@@ -10,10 +10,15 @@ class PodcastSearcher:
 
     def __init__(self, feed):
         self.feed = feed
-        self.entries = self._load_entries()
-
-    def _load_entries(self):
-        return PodcastCacher(self.feed).entries
+        
+    @property
+    def entries(self):
+        try:
+            return self._entries
+        except AttributeError:
+            pass
+        self._entries = PodcastCacher(self.feed).entries
+        return self.entries
 
     def search(self, term):
         term = term.lower()


### PR DESCRIPTION
I consider it bad manners to perform I/O (reads and writes) of unknown latency in the `__init__` method. If you are initializing a big herd of these objects, you have to wait for all of them to load their `entries` attribute until you can use them. A side-effect of this property pattern is in-memory caching of the results.